### PR TITLE
Enable logger, remove terser

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,6 @@ export default {
     typescript({
       exclude: ['**/*.test.ts', 'start-test.js', 'cookbook', 'docs', 'tests'],
     }),
-    terser(),
     json(),
     copy({
       targets: [{ src: 'src/public/*', dest: 'build/public' }],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,6 +13,7 @@ export default {
     typescript({
       exclude: ['**/*.test.ts', 'start-test.js', 'cookbook', 'docs', 'tests'],
     }),
+    terser(),
     json(),
     copy({
       targets: [{ src: 'src/public/*', dest: 'build/public' }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,12 +11,13 @@ import { prettyJSON } from 'hono/pretty-json';
 import { HTTPException } from 'hono/http-exception';
 import { compress } from 'hono/compress';
 import { getRuntimeKey } from 'hono/adapter';
-import { logger } from 'hono/logger';
+import { logger as honoLogger } from 'hono/logger';
 
 // import { env } from 'hono/adapter' // Have to set this up for multi-environment deployment
 
 // Middlewares
 import { requestValidator } from './middlewares/requestValidator';
+import { logger as customLogger } from './middlewares/log';
 import { hooks } from './middlewares/hooks';
 import { memoryCache } from './middlewares/cache';
 import { protection } from './utils/ecs/protection';
@@ -92,7 +93,8 @@ app.use('*', prettyJSON());
 
 // Use logger middleware for all routes
 if (getRuntimeKey() === 'node') {
-  app.use(logger());
+  app.use(honoLogger()); // Simple logs: <-- POST /v1/endpoint
+  app.use(customLogger()); // Verbose logs with full request/response
   app.use(protection());
 }
 


### PR DESCRIPTION
logger wasn't imported

Proper testing:
1. `npm run build`
2. node build/start-server.js --port=8789
3. 
```
curl http://localhost:8789/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "x-portkey-provider: openai" \
  -H "Authorization: Bearer <YOUR_API_KEY>" \
  -d '{
    "model": "gpt-3.5-turbo",
    "messages": [{"role": "user", "content": "Hello"}]
  }'
```