### PR TITLE
feat: pass thinking_level param to gemini via openai reasoning_effort

### DIFF
--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -109,14 +109,6 @@ const transformGenerationConfig = (params: Params) => {
     recursivelyDeleteUnsupportedParameters(schema);
     generationConfig['responseSchema'] = transformGeminiToolParameters(schema);
   }
-
-  if (params.reasoning_effort) {
-    const thinkingConfig: Record<string, any> = {};
-    thinkingConfig['include_thoughts'] = true;
-    thinkingConfig['thinking_level'] = params.reasoning_effort;
-    generationConfig['thinking_config'] = thinkingConfig;
-  }
-
   if (params?.thinking) {
     const thinkingConfig: Record<string, any> = {};
     const { budget_tokens, type } = params.thinking;
@@ -129,6 +121,12 @@ const transformGenerationConfig = (params: Params) => {
     generationConfig['responseModalities'] = params.modalities.map((modality) =>
       modality.toUpperCase()
     );
+  }
+  if (params.reasoning_effort && params.reasoning_effort !== 'none') {
+    const thinkingConfig: Record<string, any> = {};
+    thinkingConfig['includeThoughts'] = true;
+    thinkingConfig['thinkingLevel'] = params.reasoning_effort;
+    generationConfig['thinkingConfig'] = thinkingConfig;
   }
   return generationConfig;
 };

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -109,6 +109,14 @@ const transformGenerationConfig = (params: Params) => {
     recursivelyDeleteUnsupportedParameters(schema);
     generationConfig['responseSchema'] = transformGeminiToolParameters(schema);
   }
+
+  if (params.reasoning_effort) {
+    const thinkingConfig: Record<string, any> = {};
+    thinkingConfig['include_thoughts'] = true;
+    thinkingConfig['thinking_level'] = params.reasoning_effort;
+    generationConfig['thinking_config'] = thinkingConfig;
+  }
+
   if (params?.thinking) {
     const thinkingConfig: Record<string, any> = {};
     const { budget_tokens, type } = params.thinking;
@@ -474,6 +482,10 @@ export const GoogleChatCompleteConfig: ProviderConfig = {
     },
   },
   thinking: {
+    param: 'generationConfig',
+    transform: (params: Params) => transformGenerationConfig(params),
+  },
+  reasoning_effort: {
     param: 'generationConfig',
     transform: (params: Params) => transformGenerationConfig(params),
   },


### PR DESCRIPTION
**Description:** (required)
This PR updates the `generationConfig` transformation logic for the `google` provider to set the gemini `thinking_level` param via the openai `reasoning_effort` param.  The `thinking_level` parameter is used for the google gemini 3.0 family of models to control how much the model thinks before answering.

These parameters share the following values:
- `"minimal"`
- `"low"`
- `"medium"`
- `"high"`

OpenAI's `reasoning_effort` param also supports `"none"`, which we ignore.


Relevant documentation:
- https://ai.google.dev/gemini-api/docs/thinking#thinking-levels
- https://ai.google.dev/api/generate-content#ThinkingConfig
- https://portkey.ai/docs/integrations/llms/gemini#using-reasoning_effort-parameter

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)