### PR TITLE
fix: correctly transform google api usage to openai completions usage

### DIFF
--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -38,6 +38,43 @@ type ToolCallWithSignature = ToolCall & {
   thoughtSignature: string | undefined;
 };
 
+const convertGoogleApiUsageMetadataToOpenAiUsageMetadata = (
+  usageMetadata: GoogleGenerateContentResponse['usageMetadata']
+) => {
+  const {
+    promptTokenCount = 0,
+    toolUsePromptTokenCount = 0,
+    candidatesTokenCount = 0,
+    totalTokenCount = 0,
+    thoughtsTokenCount = 0,
+    cachedContentTokenCount = 0,
+    promptTokensDetails = [],
+    candidatesTokensDetails = [],
+  } = usageMetadata;
+  const inputAudioTokens = promptTokensDetails.reduce((acc, curr) => {
+    if (curr.modality === VERTEX_MODALITY.AUDIO) return acc + curr.tokenCount;
+    return acc;
+  }, 0);
+  const outputAudioTokens = candidatesTokensDetails.reduce((acc, curr) => {
+    if (curr.modality === VERTEX_MODALITY.AUDIO) return acc + curr.tokenCount;
+    return acc;
+  }, 0);
+
+  return {
+    prompt_tokens: promptTokenCount + toolUsePromptTokenCount,
+    completion_tokens: candidatesTokenCount + thoughtsTokenCount,
+    total_tokens: totalTokenCount,
+    completion_tokens_details: {
+      reasoning_tokens: thoughtsTokenCount,
+      audio_tokens: outputAudioTokens,
+    },
+    prompt_tokens_details: {
+      cached_tokens: cachedContentTokenCount,
+      audio_tokens: inputAudioTokens,
+    },
+  };
+};
+
 const joinSystemMessages = (messages: Message[]) =>
   messages
     ?.filter((message) => message.role === 'system')
@@ -562,6 +599,7 @@ interface GoogleGenerateContentResponse {
   };
   usageMetadata: {
     promptTokenCount: number;
+    toolUsePromptTokenCount?: number;
     candidatesTokenCount: number;
     totalTokenCount: number;
     thoughtsTokenCount?: number;
@@ -615,24 +653,6 @@ export const GoogleChatCompleteResponseTransform: (
   }
 
   if ('candidates' in response) {
-    const {
-      promptTokenCount = 0,
-      candidatesTokenCount = 0,
-      totalTokenCount = 0,
-      thoughtsTokenCount = 0,
-      cachedContentTokenCount = 0,
-      promptTokensDetails = [],
-      candidatesTokensDetails = [],
-    } = response.usageMetadata;
-    const inputAudioTokens = promptTokensDetails.reduce((acc, curr) => {
-      if (curr.modality === VERTEX_MODALITY.AUDIO) return acc + curr.tokenCount;
-      return acc;
-    }, 0);
-    const outputAudioTokens = candidatesTokensDetails.reduce((acc, curr) => {
-      if (curr.modality === VERTEX_MODALITY.AUDIO) return acc + curr.tokenCount;
-      return acc;
-    }, 0);
-
     return {
       id: getFakeId(),
       object: 'chat.completion',
@@ -701,19 +721,9 @@ export const GoogleChatCompleteResponseTransform: (
               : {}),
           };
         }) ?? [],
-      usage: {
-        prompt_tokens: promptTokenCount,
-        completion_tokens: candidatesTokenCount,
-        total_tokens: totalTokenCount,
-        completion_tokens_details: {
-          reasoning_tokens: thoughtsTokenCount,
-          audio_tokens: outputAudioTokens,
-        },
-        prompt_tokens_details: {
-          cached_tokens: cachedContentTokenCount,
-          audio_tokens: inputAudioTokens,
-        },
-      },
+      usage: convertGoogleApiUsageMetadataToOpenAiUsageMetadata(
+        response.usageMetadata
+      ),
     };
   }
 
@@ -754,34 +764,9 @@ export const GoogleChatCompleteStreamChunkTransform: (
 
   let usageMetadata;
   if (parsedChunk.usageMetadata) {
-    usageMetadata = {
-      prompt_tokens: parsedChunk.usageMetadata.promptTokenCount,
-      completion_tokens: parsedChunk.usageMetadata.candidatesTokenCount,
-      total_tokens: parsedChunk.usageMetadata.totalTokenCount,
-      completion_tokens_details: {
-        reasoning_tokens: parsedChunk.usageMetadata.thoughtsTokenCount ?? 0,
-        audio_tokens:
-          parsedChunk.usageMetadata?.candidatesTokensDetails?.reduce(
-            (acc, curr) => {
-              if (curr.modality === VERTEX_MODALITY.AUDIO)
-                return acc + curr.tokenCount;
-              return acc;
-            },
-            0
-          ),
-      },
-      prompt_tokens_details: {
-        cached_tokens: parsedChunk.usageMetadata.cachedContentTokenCount,
-        audio_tokens: parsedChunk.usageMetadata?.promptTokensDetails?.reduce(
-          (acc, curr) => {
-            if (curr.modality === VERTEX_MODALITY.AUDIO)
-              return acc + curr.tokenCount;
-            return acc;
-          },
-          0
-        ),
-      },
-    };
+    usageMetadata = convertGoogleApiUsageMetadataToOpenAiUsageMetadata(
+      parsedChunk.usageMetadata
+    );
   }
 
   return (

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -1,12 +1,11 @@
 import { GOOGLE } from '../../globals';
 import {
-  ContentType,
-  Message,
-  OpenAIMessageRole,
-  Params,
-  ToolCall,
-  ToolChoice,
-  SYSTEM_MESSAGE_ROLES,
+  type ContentType,
+  type Message,
+  type OpenAIMessageRole,
+  type Params,
+  type ToolCall,
+  type ToolChoice,
   MESSAGE_ROLES,
 } from '../../types/requestBody';
 import { VERTEX_MODALITY } from '../google-vertex-ai/types';
@@ -19,7 +18,7 @@ import {
   transformInputAudioPart,
   transformVertexLogprobs,
 } from '../google-vertex-ai/utils';
-import {
+import type {
   ChatCompletionResponse,
   ErrorResponse,
   GroundingMetadata,
@@ -32,13 +31,13 @@ import {
   getFakeId,
   transformFinishReason,
 } from '../utils';
-import { GOOGLE_GENERATE_CONTENT_FINISH_REASON } from './types';
+import type { GOOGLE_GENERATE_CONTENT_FINISH_REASON } from './types';
 
 type ToolCallWithSignature = ToolCall & {
   thoughtSignature: string | undefined;
 };
 
-const convertGoogleApiUsageMetadataToOpenAiUsageMetadata = (
+const convertGoogleApiUsageMetadataToOpenAIUsageMetadata = (
   usageMetadata: GoogleGenerateContentResponse['usageMetadata']
 ) => {
   const {
@@ -721,7 +720,7 @@ export const GoogleChatCompleteResponseTransform: (
               : {}),
           };
         }) ?? [],
-      usage: convertGoogleApiUsageMetadataToOpenAiUsageMetadata(
+      usage: convertGoogleApiUsageMetadataToOpenAIUsageMetadata(
         response.usageMetadata
       ),
     };
@@ -764,7 +763,7 @@ export const GoogleChatCompleteStreamChunkTransform: (
 
   let usageMetadata;
   if (parsedChunk.usageMetadata) {
-    usageMetadata = convertGoogleApiUsageMetadataToOpenAiUsageMetadata(
+    usageMetadata = convertGoogleApiUsageMetadataToOpenAIUsageMetadata(
       parsedChunk.usageMetadata
     );
   }


### PR DESCRIPTION
**Description:** (required)
This PR fixes the logic for transforming usage metadata from the google api to the format and convention expected by the ChatCompletions API. 

This includes:
1. Including tool definition tokens in prompt token count
2. Including thinking tokens in total completion token count

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)