### PR TITLE
fix: correctly transform anthropic usage to openai completions usage (anthropic + vertex)

### DIFF
--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -523,7 +523,6 @@ export interface AnthropicChatCompleteStreamResponse {
   error?: AnthropicErrorObject;
 }
 
-// TODO: The token calculation is wrong atm
 export const AnthropicChatCompleteResponseTransform: (
   response: AnthropicChatCompleteResponse | AnthropicErrorResponse,
   responseStatus: number,

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -1,24 +1,23 @@
 import { ANTHROPIC, fileExtensionMimeTypeMap } from '../../globals';
 import {
-  Params,
-  Message,
-  ContentType,
+  type Params,
+  type Message,
+  type ContentType,
   SYSTEM_MESSAGE_ROLES,
-  PromptCache,
+  type PromptCache,
 } from '../../types/requestBody';
-import {
+import type {
   ChatCompletionResponse,
   ErrorResponse,
   ProviderConfig,
 } from '../types';
-import {
+import type {
   AnthropicErrorObject,
   AnthropicErrorResponse,
   AnthropicStreamState,
   ANTHROPIC_STOP_REASON,
 } from './types';
 import {
-  generateErrorResponse,
   generateInvalidProviderResponseError,
   transformFinishReason,
 } from '../utils';

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -22,6 +22,7 @@ import {
   transformFinishReason,
 } from '../utils';
 import { AnthropicErrorResponseTransform } from './utils';
+import { transformAnthropicUsageMetadata } from '../utils/transformAnthropicUsageMetadata';
 
 // TODO: this configuration does not enforce the maximum token limit for the input parameter. If you want to enforce this, you might need to add a custom validation function or a max property to the ParameterConfig interface, and then use it in the input configuration. However, this might be complex because the token count is not a simple length check, but depends on the specific tokenization method used by the model.
 
@@ -254,42 +255,6 @@ const transformAndAppendFileContentItem = (
       },
     });
   }
-};
-
-const transformAnthropicUsageMetadata = (
-  usageMetadata:
-    | NonNullable<AnthropicChatCompleteResponse['usage']>
-    | NonNullable<AnthropicChatCompleteStreamResponse['usage']>
-) => {
-  const {
-    input_tokens = 0,
-    output_tokens = 0,
-    cache_creation_input_tokens = 0,
-    cache_read_input_tokens = 0,
-  } = usageMetadata;
-
-  const shouldSendCacheUsage =
-    cache_creation_input_tokens || cache_read_input_tokens;
-
-  return {
-    prompt_tokens:
-      input_tokens + cache_creation_input_tokens + cache_read_input_tokens,
-    completion_tokens: output_tokens,
-    total_tokens:
-      input_tokens +
-      output_tokens +
-      cache_creation_input_tokens +
-      cache_read_input_tokens,
-    ...(shouldSendCacheUsage && {
-      prompt_tokens_details: {
-        cached_tokens: cache_read_input_tokens,
-      },
-    }),
-    ...(shouldSendCacheUsage && {
-      cache_read_input_tokens: cache_read_input_tokens,
-      cache_creation_input_tokens: cache_creation_input_tokens,
-    }),
-  };
 };
 
 export const AnthropicChatCompleteConfig: ProviderConfig = {

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -257,6 +257,42 @@ const transformAndAppendFileContentItem = (
   }
 };
 
+const transformAnthropicUsageMetadata = (
+  usageMetadata:
+    | NonNullable<AnthropicChatCompleteResponse['usage']>
+    | NonNullable<AnthropicChatCompleteStreamResponse['usage']>
+) => {
+  const {
+    input_tokens = 0,
+    output_tokens = 0,
+    cache_creation_input_tokens = 0,
+    cache_read_input_tokens = 0,
+  } = usageMetadata;
+
+  const shouldSendCacheUsage =
+    cache_creation_input_tokens || cache_read_input_tokens;
+
+  return {
+    prompt_tokens:
+      input_tokens + cache_creation_input_tokens + cache_read_input_tokens,
+    completion_tokens: output_tokens,
+    total_tokens:
+      input_tokens +
+      output_tokens +
+      cache_creation_input_tokens +
+      cache_read_input_tokens,
+    ...(shouldSendCacheUsage && {
+      prompt_tokens_details: {
+        cached_tokens: cache_read_input_tokens,
+      },
+    }),
+    ...(shouldSendCacheUsage && {
+      cache_read_input_tokens: cache_read_input_tokens,
+      cache_creation_input_tokens: cache_creation_input_tokens,
+    }),
+  };
+};
+
 export const AnthropicChatCompleteConfig: ProviderConfig = {
   model: {
     param: 'model',
@@ -540,16 +576,6 @@ export const AnthropicChatCompleteResponseTransform: (
   }
 
   if ('content' in response) {
-    const {
-      input_tokens = 0,
-      output_tokens = 0,
-      cache_creation_input_tokens,
-      cache_read_input_tokens,
-    } = response?.usage;
-
-    const shouldSendCacheUsage =
-      cache_creation_input_tokens || cache_read_input_tokens;
-
     let content: string = '';
     response.content.forEach((item) => {
       if (item.type === 'text') {
@@ -597,22 +623,7 @@ export const AnthropicChatCompleteResponseTransform: (
           ),
         },
       ],
-      usage: {
-        prompt_tokens: input_tokens,
-        completion_tokens: output_tokens,
-        total_tokens:
-          input_tokens +
-          output_tokens +
-          (cache_creation_input_tokens ?? 0) +
-          (cache_read_input_tokens ?? 0),
-        prompt_tokens_details: {
-          cached_tokens: cache_read_input_tokens ?? 0,
-        },
-        ...(shouldSendCacheUsage && {
-          cache_read_input_tokens: cache_read_input_tokens,
-          cache_creation_input_tokens: cache_creation_input_tokens,
-        }),
-      },
+      usage: transformAnthropicUsageMetadata(response.usage),
     };
   }
 
@@ -677,21 +688,11 @@ export const AnthropicChatCompleteStreamChunkTransform: (
     );
   }
 
-  const shouldSendCacheUsage =
-    parsedChunk.message?.usage?.cache_read_input_tokens ||
-    parsedChunk.message?.usage?.cache_creation_input_tokens;
-
   if (parsedChunk.type === 'message_start' && parsedChunk.message?.usage) {
     streamState.model = parsedChunk?.message?.model ?? '';
-    streamState.usage = {
-      prompt_tokens: parsedChunk.message?.usage?.input_tokens,
-      ...(shouldSendCacheUsage && {
-        cache_read_input_tokens:
-          parsedChunk.message?.usage?.cache_read_input_tokens,
-        cache_creation_input_tokens:
-          parsedChunk.message?.usage?.cache_creation_input_tokens,
-      }),
-    };
+    streamState.usage = transformAnthropicUsageMetadata(
+      parsedChunk.message?.usage
+    );
     return (
       `data: ${JSON.stringify({
         id: fallbackId,
@@ -716,11 +717,6 @@ export const AnthropicChatCompleteStreamChunkTransform: (
 
   // final chunk
   if (parsedChunk.type === 'message_delta' && parsedChunk.usage) {
-    const totalTokens =
-      (streamState?.usage?.prompt_tokens ?? 0) +
-      (streamState?.usage?.cache_creation_input_tokens ?? 0) +
-      (streamState?.usage?.cache_read_input_tokens ?? 0) +
-      (parsedChunk.usage.output_tokens ?? 0);
     return (
       `data: ${JSON.stringify({
         id: fallbackId,
@@ -738,14 +734,7 @@ export const AnthropicChatCompleteStreamChunkTransform: (
             ),
           },
         ],
-        usage: {
-          ...streamState.usage,
-          completion_tokens: parsedChunk.usage?.output_tokens,
-          total_tokens: totalTokens,
-          prompt_tokens_details: {
-            cached_tokens: streamState.usage?.cache_read_input_tokens ?? 0,
-          },
-        },
+        usage: transformAnthropicUsageMetadata(parsedChunk.usage),
       })}` + '\n\n'
     );
   }

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -3,33 +3,33 @@
 
 import { GOOGLE_VERTEX_AI } from '../../globals';
 import {
-  ContentType,
-  Message,
-  Params,
-  ToolCall,
+  type ContentType,
+  type Message,
+  type Params,
+  type ToolCall,
   SYSTEM_MESSAGE_ROLES,
   MESSAGE_ROLES,
 } from '../../types/requestBody';
 import {
   AnthropicChatCompleteConfig,
-  AnthropicChatCompleteResponse,
-  AnthropicChatCompleteStreamResponse,
+  type AnthropicChatCompleteResponse,
+  type AnthropicChatCompleteStreamResponse,
 } from '../anthropic/chatComplete';
-import {
+import type {
   AnthropicStreamState,
   AnthropicErrorResponse,
 } from '../anthropic/types';
 import {
-  GoogleMessage,
-  GoogleMessagePart,
-  GoogleMessageRole,
-  GoogleToolConfig,
+  type GoogleMessage,
+  type GoogleMessagePart,
+  type GoogleMessageRole,
+  type GoogleToolConfig,
   SYSTEM_INSTRUCTION_DISABLED_MODELS,
   transformOpenAIRoleToGoogleRole,
   transformToolChoiceForGemini,
 } from '../google/chatComplete';
-import { GOOGLE_GENERATE_CONTENT_FINISH_REASON } from '../google/types';
-import {
+import type { GOOGLE_GENERATE_CONTENT_FINISH_REASON } from '../google/types';
+import type {
   ChatCompletionResponse,
   ErrorResponse,
   Logprobs,
@@ -44,11 +44,10 @@ import {
 import { transformAnthropicUsageMetadata } from '../utils/transformAnthropicUsageMetadata';
 import { transformGenerationConfig } from './transformGenerationConfig';
 import {
-  GoogleErrorResponse,
-  GoogleGenerateContentResponse,
-  VertexLlamaChatCompleteStreamChunk,
-  VertexLLamaChatCompleteResponse,
-  GoogleSearchRetrievalTool,
+  type GoogleErrorResponse,
+  type GoogleGenerateContentResponse,
+  type VertexLlamaChatCompleteStreamChunk,
+  type VertexLLamaChatCompleteResponse,
   VERTEX_MODALITY,
 } from './types';
 import {

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -41,6 +41,7 @@ import {
   getFakeId,
   transformFinishReason,
 } from '../utils';
+import { transformAnthropicUsageMetadata } from '../utils/transformAnthropicUsageMetadata';
 import { transformGenerationConfig } from './transformGenerationConfig';
 import {
   GoogleErrorResponse,
@@ -846,18 +847,7 @@ export const VertexAnthropicChatCompleteResponseTransform: (
           ),
         },
       ],
-      usage: {
-        prompt_tokens: input_tokens,
-        completion_tokens: output_tokens,
-        total_tokens: totalTokens,
-        prompt_tokens_details: {
-          cached_tokens: cache_read_input_tokens,
-        },
-        ...(shouldSendCacheUsage && {
-          cache_read_input_tokens: cache_read_input_tokens,
-          cache_creation_input_tokens: cache_creation_input_tokens,
-        }),
-      },
+      usage: transformAnthropicUsageMetadata(response.usage),
     };
   }
 
@@ -925,21 +915,10 @@ export const VertexAnthropicChatCompleteStreamChunkTransform: (
   }
 
   if (parsedChunk.type === 'message_start' && parsedChunk.message?.usage) {
-    const shouldSendCacheUsage =
-      parsedChunk.message?.usage?.cache_read_input_tokens ||
-      parsedChunk.message?.usage?.cache_creation_input_tokens;
-
     streamState.model = parsedChunk?.message?.model ?? '';
-
-    streamState.usage = {
-      prompt_tokens: parsedChunk.message.usage?.input_tokens,
-      ...(shouldSendCacheUsage && {
-        cache_read_input_tokens:
-          parsedChunk.message?.usage?.cache_read_input_tokens,
-        cache_creation_input_tokens:
-          parsedChunk.message?.usage?.cache_creation_input_tokens,
-      }),
-    };
+    streamState.usage = transformAnthropicUsageMetadata(
+      parsedChunk.message?.usage
+    );
     return (
       `data: ${JSON.stringify({
         id: fallbackId,
@@ -957,9 +936,7 @@ export const VertexAnthropicChatCompleteStreamChunkTransform: (
             finish_reason: null,
           },
         ],
-        usage: {
-          prompt_tokens: streamState.usage.prompt_tokens,
-        },
+        usage: streamState.usage,
       })}` + '\n\n'
     );
   }
@@ -967,9 +944,15 @@ export const VertexAnthropicChatCompleteStreamChunkTransform: (
   if (parsedChunk.type === 'message_delta' && parsedChunk.usage) {
     const totalTokens =
       (streamState?.usage?.prompt_tokens ?? 0) +
-      (streamState?.usage?.cache_creation_input_tokens ?? 0) +
-      (streamState?.usage?.cache_read_input_tokens ?? 0) +
       (parsedChunk.usage.output_tokens ?? 0);
+
+    const usageMetadata = {
+      ...streamState.usage,
+      completion_tokens:
+        parsedChunk.usage?.output_tokens ??
+        streamState.usage?.completion_tokens,
+      total_tokens: totalTokens,
+    };
 
     return (
       `data: ${JSON.stringify({
@@ -988,14 +971,7 @@ export const VertexAnthropicChatCompleteStreamChunkTransform: (
             ),
           },
         ],
-        usage: {
-          ...streamState.usage,
-          completion_tokens: parsedChunk.usage?.output_tokens,
-          total_tokens: totalTokens,
-          prompt_tokens_details: {
-            cached_tokens: streamState.usage?.cache_read_input_tokens ?? 0,
-          },
-        },
+        usage: usageMetadata,
       })}` + '\n\n'
     );
   }

--- a/src/providers/utils/transformAnthropicUsageMetadata.ts
+++ b/src/providers/utils/transformAnthropicUsageMetadata.ts
@@ -1,0 +1,40 @@
+import type {
+  AnthropicChatCompleteResponse,
+  AnthropicChatCompleteStreamResponse,
+} from '../anthropic/chatComplete';
+
+export const transformAnthropicUsageMetadata = (
+  usageMetadata:
+    | AnthropicChatCompleteResponse['usage']
+    | NonNullable<AnthropicChatCompleteStreamResponse['usage']>
+) => {
+  const {
+    input_tokens = 0,
+    output_tokens = 0,
+    cache_creation_input_tokens = 0,
+    cache_read_input_tokens = 0,
+  } = usageMetadata;
+
+  const shouldSendCacheUsage =
+    cache_creation_input_tokens || cache_read_input_tokens;
+
+  return {
+    prompt_tokens:
+      input_tokens + cache_creation_input_tokens + cache_read_input_tokens,
+    completion_tokens: output_tokens,
+    total_tokens:
+      input_tokens +
+      output_tokens +
+      cache_creation_input_tokens +
+      cache_read_input_tokens,
+    ...(shouldSendCacheUsage && {
+      prompt_tokens_details: {
+        cached_tokens: cache_read_input_tokens,
+      },
+    }),
+    ...(shouldSendCacheUsage && {
+      cache_read_input_tokens: cache_read_input_tokens,
+      cache_creation_input_tokens: cache_creation_input_tokens,
+    }),
+  };
+};


### PR DESCRIPTION
**Description:** (required)
This PR fixes the logic for transforming Anthropic usage metadata to the OpenAI chat completions api standard. This is done for the Anthropic and VertexAI providers

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)