### PR TITLE
fix: prefetch image URLs for Anthropic direct provider

### DIFF
--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -125,6 +125,9 @@ const imageURLToBase64 = async (url: string) => {
       const arrayBuffer = await response.arrayBuffer();
       const buffer = Buffer.from(arrayBuffer);
       const contentType = response.headers.get('content-type')?.split(';')[0];
+      if (!contentType) {
+        throw new Error('Missing content type in response');
+      }
       const base64String = buffer.toString('base64');
       const prefix = `data:${contentType};base64,`;
       return { prefix, base64String };

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -109,11 +109,7 @@ export function getFakeId() {
   return ('portkey-' + crypto.randomUUID()).slice(0, 40);
 }
 
-// Fetches an image URL and converts it to a base64 data URI.
-// Uses retry() which guarantees a binary outcome: resolves with { prefix, base64String }
-// or rejects. It will never resolve with null/undefined, so callers can safely destructure.
 const imageURLToBase64 = async (url: string) => {
-  // Uploadcare CDN URLs need `-/preview/` appended to return a rasterized image
   const urlWithTransformation = url.startsWith('https://ucarecdn.com/')
     ? urljoin(url, '-/preview/')
     : url;
@@ -129,8 +125,6 @@ const imageURLToBase64 = async (url: string) => {
       const arrayBuffer = await response.arrayBuffer();
       const buffer = Buffer.from(arrayBuffer);
       const contentType = response.headers.get('content-type')?.split(';')[0];
-      // Without a valid content-type, the data URI would be `data:undefined;base64,...`
-      // which produces a corrupt image the model can't parse.
       if (!contentType) {
         throw new Error('Missing content type in response');
       }
@@ -149,12 +143,6 @@ const imageURLToBase64 = async (url: string) => {
   );
 };
 
-// Converts all image_url content blocks in messages from remote URLs to inline base64 data URIs.
-// This is necessary because some providers (Bedrock, Vertex AI) require base64, and others
-// (Anthropic direct) technically support URL-based images but fail silently when fetching
-// Uploadcare CDN URLs — causing the model to hallucinate about screenshot content.
-// On failure, replaces the image with descriptive text so the model knows an image was
-// intended rather than silently receiving nothing and hallucinating.
 export async function prefetchImageUrls(
   messages: Message[]
 ): Promise<Message[]> {
@@ -174,8 +162,6 @@ export async function prefetchImageUrls(
             `Failed to prefetch image after retries: ${item.image_url.url}`,
             error
           );
-          // Replace with text so the model knows an image was intended but failed,
-          // rather than receiving nothing and hallucinating about what it should see.
           content[i] = {
             type: 'text',
             text: `[Image failed to load: ${item.image_url.url}]`,
@@ -199,10 +185,10 @@ export function shouldPrefetchImageUrls({
   if (!messages || messages.length === 0 || !model) {
     return false;
   }
-  // Providers that can't reliably fetch remote image URLs need prefetching:
-  // - Anthropic direct: supports source.type='url' but silently fails on Uploadcare CDN URLs
-  // - Vertex AI (Anthropic models): uses rawPredict which requires base64
-  // - Bedrock: only accepts base64-encoded images
+  // Anthropic direct technically supports source.type='url', but it intermittently
+  // fails to fetch Uploadcare CDN URLs — when it does, the model receives no image
+  // and hallucinates about what the screenshot shows. Prefetching to base64 makes
+  // image delivery deterministic for all three providers.
   switch (provider) {
     case ANTHROPIC:
       return true;

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -7,7 +7,7 @@ import {
   finishReasonMap,
 } from './utils/finishReasonMap';
 import { ContentType, Message } from '../types/requestBody';
-import { BEDROCK, GOOGLE_VERTEX_AI } from '../globals';
+import { ANTHROPIC, BEDROCK, GOOGLE_VERTEX_AI } from '../globals';
 import { getModelAndProvider } from './google-vertex-ai/utils';
 
 export const generateInvalidProviderResponseError: (
@@ -183,6 +183,8 @@ export function shouldPrefetchImageUrls({
     return false;
   }
   switch (provider) {
+    case ANTHROPIC:
+      return true;
     case GOOGLE_VERTEX_AI:
       return getModelAndProvider(model).provider === 'anthropic';
     case BEDROCK:

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -109,7 +109,11 @@ export function getFakeId() {
   return ('portkey-' + crypto.randomUUID()).slice(0, 40);
 }
 
+// Fetches an image URL and converts it to a base64 data URI.
+// Uses retry() which guarantees a binary outcome: resolves with { prefix, base64String }
+// or rejects. It will never resolve with null/undefined, so callers can safely destructure.
 const imageURLToBase64 = async (url: string) => {
+  // Uploadcare CDN URLs need `-/preview/` appended to return a rasterized image
   const urlWithTransformation = url.startsWith('https://ucarecdn.com/')
     ? urljoin(url, '-/preview/')
     : url;
@@ -125,6 +129,8 @@ const imageURLToBase64 = async (url: string) => {
       const arrayBuffer = await response.arrayBuffer();
       const buffer = Buffer.from(arrayBuffer);
       const contentType = response.headers.get('content-type')?.split(';')[0];
+      // Without a valid content-type, the data URI would be `data:undefined;base64,...`
+      // which produces a corrupt image the model can't parse.
       if (!contentType) {
         throw new Error('Missing content type in response');
       }
@@ -143,6 +149,12 @@ const imageURLToBase64 = async (url: string) => {
   );
 };
 
+// Converts all image_url content blocks in messages from remote URLs to inline base64 data URIs.
+// This is necessary because some providers (Bedrock, Vertex AI) require base64, and others
+// (Anthropic direct) technically support URL-based images but fail silently when fetching
+// Uploadcare CDN URLs — causing the model to hallucinate about screenshot content.
+// On failure, replaces the image with descriptive text so the model knows an image was
+// intended rather than silently receiving nothing and hallucinating.
 export async function prefetchImageUrls(
   messages: Message[]
 ): Promise<Message[]> {
@@ -162,6 +174,8 @@ export async function prefetchImageUrls(
             `Failed to prefetch image after retries: ${item.image_url.url}`,
             error
           );
+          // Replace with text so the model knows an image was intended but failed,
+          // rather than receiving nothing and hallucinating about what it should see.
           content[i] = {
             type: 'text',
             text: `[Image failed to load: ${item.image_url.url}]`,
@@ -185,6 +199,10 @@ export function shouldPrefetchImageUrls({
   if (!messages || messages.length === 0 || !model) {
     return false;
   }
+  // Providers that can't reliably fetch remote image URLs need prefetching:
+  // - Anthropic direct: supports source.type='url' but silently fails on Uploadcare CDN URLs
+  // - Vertex AI (Anthropic models): uses rawPredict which requires base64
+  // - Bedrock: only accepts base64-encoded images
   switch (provider) {
     case ANTHROPIC:
       return true;

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -1,3 +1,4 @@
+import retry from 'async-retry';
 import urljoin from 'url-join';
 import { ANTHROPIC_STOP_REASON } from './anthropic/types';
 import { FINISH_REASON, ErrorResponse, PROVIDER_FINISH_REASON } from './types';
@@ -113,25 +114,30 @@ const imageURLToBase64 = async (url: string) => {
     ? urljoin(url, '-/preview/')
     : url;
 
-  try {
-    const response = await fetch(urlWithTransformation, {
-      signal: AbortSignal.timeout(10000),
-    });
-    if (!response.ok) {
-      throw new Error(`Failed to fetch image. Status: ${response.status}`);
+  return retry(
+    async () => {
+      const response = await fetch(urlWithTransformation, {
+        signal: AbortSignal.timeout(10000),
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch image. Status: ${response.status}`);
+      }
+      const arrayBuffer = await response.arrayBuffer();
+      const buffer = Buffer.from(arrayBuffer);
+      const contentType = response.headers.get('content-type')?.split(';')[0];
+      const base64String = buffer.toString('base64');
+      const prefix = `data:${contentType};base64,`;
+      return { prefix, base64String };
+    },
+    {
+      retries: 3,
+      onRetry: (error, attempt) => {
+        console.warn(
+          `Image prefetch attempt ${attempt} failed for ${url}: ${error.message}`
+        );
+      },
     }
-    const arrayBuffer = await response.arrayBuffer();
-    const buffer = Buffer.from(arrayBuffer);
-    const contentType = response.headers.get('content-type')?.split(';')[0];
-    const base64String = buffer.toString('base64');
-    const prefix = `data:${contentType};base64,`;
-    return {
-      prefix,
-      base64String,
-    };
-  } catch (error) {
-    console.error('Error trying to encode image url', error);
-  }
+  );
 };
 
 export async function prefetchImageUrls(
@@ -140,12 +146,23 @@ export async function prefetchImageUrls(
   for (const msg of messages) {
     const content: ContentType[] =
       msg.content_blocks ?? (Array.isArray(msg.content) ? msg.content : []);
-    for (const item of content) {
+    for (let i = 0; i < content.length; i++) {
+      const item = content[i];
       if (item.type === 'image_url' && item.image_url?.url) {
-        const data = await imageURLToBase64(item.image_url.url);
-        if (data) {
-          const { prefix, base64String } = data;
+        try {
+          const { prefix, base64String } = await imageURLToBase64(
+            item.image_url.url
+          );
           item.image_url.url = `${prefix}${base64String}`;
+        } catch (error) {
+          console.error(
+            `Failed to prefetch image after retries: ${item.image_url.url}`,
+            error
+          );
+          content[i] = {
+            type: 'text',
+            text: `[Image failed to load: ${item.image_url.url}]`,
+          } as ContentType;
         }
       }
     }


### PR DESCRIPTION
## Summary

- Extend `shouldPrefetchImageUrls()` to also cover the Anthropic direct provider, not just Bedrock and Vertex AI
- When traffic routes to Anthropic direct, image URLs (e.g. Uploadcare CDN screenshots) were passed through as `source.type: 'url'` — Anthropic's server-side URL fetching intermittently fails, causing the model to receive no image content and hallucinate about what screenshots show
- With this fix, all image URLs are fetched and converted to base64 before being sent to Anthropic, matching the existing behavior for Bedrock and Vertex AI
- Also adds a guard against missing `content-type` headers in prefetch responses, which would produce corrupt `data:undefined;base64,...` data URIs

## Context

Confirmed via production CloudWatch logs for a project group where the model's thinking blocks explicitly stated *"The screenshots didn't load as images in the conversation"* — then proceeded to say *"The desktop screenshot looks great"* based on code inference rather than visual inspection.

## Manual QA

Ran the gateway locally and tested with cURL against `x-portkey-provider: anthropic`:

| Scenario | Command | Result |
|----------|---------|--------|
| Successful image prefetch (5x) | `image_url` with Google logo PNG | 5/5 correct — model consistently identifies the Google logo with correct colors. Gateway logs show `Prefetching image URLs for messages` for all 5 requests. |
| Failed image prefetch (429) | `image_url` with Wikipedia PNG (rate-limited) | Gateway retries 3x, logs `Image prefetch attempt N failed ... Status: 429`, replaces with `[Image failed to load: URL]` text, model responds: *"I'm unable to see the image as it failed to load"* — no hallucination |

5x successful prefetch results:
```
Run 1: "This is the colorful Google logo featuring the company name in blue, red, yellow, and green letters."
Run 2: "The image shows the colorful Google logo with its characteristic blue "G", red "o", yellow "o", blue "g", green "l", and red "e" letters."
Run 3: "The image shows Google's colorful logo with letters in blue, red, yellow, and green."
Run 4: "This is the colorful Google logo featuring the company name in blue, red, yellow, blue, green, and red letters."
Run 5: "The image shows the colorful Google logo with letters in blue, red, yellow, and green."
```

Gateway logs confirming prefetch triggers for Anthropic provider:
```
Prefetching image URLs for messages   (x5 — one per successful request)

Prefetching image URLs for messages
Image prefetch attempt 1 failed for https://upload.wikimedia.org/...: Failed to fetch image. Status: 429
Image prefetch attempt 2 failed for https://upload.wikimedia.org/...: Failed to fetch image. Status: 429
Image prefetch attempt 3 failed for https://upload.wikimedia.org/...: Failed to fetch image. Status: 429
Failed to prefetch image after retries: https://upload.wikimedia.org/...
```