### PR TITLE
fix: add debug logging for Vertex AI image visibility issue

### DIFF
--- a/src/handlers/services/requestContext.ts
+++ b/src/handlers/services/requestContext.ts
@@ -221,6 +221,67 @@ export class RequestContext {
       this.requestHeaders,
       this.providerOption
     );
+    this.logImageContentParts();
+  }
+
+  private logImageContentParts() {
+    const body = this.transformedRequestBody;
+    if (!body || typeof body !== 'object' || !('messages' in body)) {
+      return;
+    }
+    const messages = (body as Record<string, unknown>).messages;
+    if (!Array.isArray(messages)) {
+      return;
+    }
+    const imageSummary: Array<{
+      messageIndex: number;
+      role: string;
+      type: string;
+      sourceType?: string;
+      mediaType?: string;
+      dataLength?: number;
+    }> = [];
+    for (let i = 0; i < messages.length; i++) {
+      const msg = messages[i];
+      if (!msg?.content || !Array.isArray(msg.content)) {
+        continue;
+      }
+      for (const part of msg.content) {
+        if (part?.type === 'image' && part?.source) {
+          imageSummary.push({
+            messageIndex: i,
+            role: msg.role,
+            type: part.type,
+            sourceType: part.source.type,
+            mediaType: part.source.media_type,
+            dataLength:
+              part.source.type === 'base64'
+                ? part.source.data?.length
+                : undefined,
+          });
+        } else if (part?.type === 'image_url' && part?.image_url) {
+          const url = part.image_url.url ?? '';
+          imageSummary.push({
+            messageIndex: i,
+            role: msg.role,
+            type: part.type,
+            sourceType: url.startsWith('data:') ? 'base64-datauri' : 'url',
+            dataLength: url.length,
+          });
+        }
+      }
+    }
+    if (imageSummary.length > 0) {
+      console.log(
+        JSON.stringify({
+          msg: 'Image content parts in transformed request',
+          provider: this.provider,
+          endpoint: this.endpoint,
+          imageCount: imageSummary.length,
+          images: imageSummary,
+        })
+      );
+    }
   }
 
   get requestOptions(): any[] {

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -191,8 +191,16 @@ const transformAndAppendImageContentItem = (
   item: ContentType,
   transformedMessage: AnthropicMessage
 ) => {
-  if (!item?.image_url?.url || typeof transformedMessage.content === 'string')
+  if (!item?.image_url?.url || typeof transformedMessage.content === 'string') {
+    console.log(
+      JSON.stringify({
+        msg: 'transformAndAppendImageContentItem: skipped',
+        hasUrl: !!item?.image_url?.url,
+        contentIsString: typeof transformedMessage.content === 'string',
+      })
+    );
     return;
+  }
   const url = item.image_url.url;
   const isBase64EncodedImage = url.startsWith('data:');
   if (!isBase64EncodedImage) {
@@ -203,6 +211,12 @@ const transformAndAppendImageContentItem = (
         url,
       },
     });
+    console.log(
+      JSON.stringify({
+        msg: 'transformAndAppendImageContentItem: added url image',
+        urlPrefix: url.substring(0, 60),
+      })
+    );
   } else {
     const parts = url.split(';');
     if (parts.length === 2) {
@@ -223,7 +237,31 @@ const transformAndAppendImageContentItem = (
             cache_control: { type: 'ephemeral' },
           }),
         });
+        console.log(
+          JSON.stringify({
+            msg: 'transformAndAppendImageContentItem: added base64 image',
+            mediaType,
+            dataLength: base64Image.length,
+          })
+        );
+      } else {
+        console.log(
+          JSON.stringify({
+            msg: 'transformAndAppendImageContentItem: base64 parse failed',
+            partsLength: parts.length,
+            mediaTypePartsLength: mediaTypeParts.length,
+            hasBase64Image: !!base64Image,
+          })
+        );
       }
+    } else {
+      console.log(
+        JSON.stringify({
+          msg: 'transformAndAppendImageContentItem: semicolon split unexpected',
+          partsLength: parts.length,
+          urlPrefix: url.substring(0, 60),
+        })
+      );
     }
   }
 };


### PR DESCRIPTION
## Summary

Images sent via Vertex AI are consistently not visible to the model — 50/50 matched instances are Vertex AI, 0 from direct Anthropic or Bedrock. Adding debug logging to trace the image transformation pipeline and identify where images are lost.

## What this logs

1. **`transformAndAppendImageContentItem`** — logs which branch is taken (base64 parse success, URL pass-through, skip, or parse failure) with metadata (mediaType, dataLength) but NOT the actual base64 data
2. **`logImageContentParts`** — logs a summary of all image content parts in the final transformed request body, showing whether they're in Anthropic format (`type: "image"`) or still in OpenAI format (`type: "image_url"`)

## Context

- CloudWatch worker logs show the model's thinking blocks saying "screenshot didn't load" / "no image was shown" 50 times, all Vertex AI
- The gateway's client request body contains the images correctly (confirmed via gateway logs)
- The transformation code looks correct on paper but we can't see the actual transformed request sent to Vertex AI
- These logs will tell us definitively whether images survive the transformation

## Risks

- Logging overhead is minimal (only triggers when images are present, logs metadata not data)
- No functional changes to the transformation pipeline