### PR TITLE
feat: add effort param and adaptive thinking support

### DIFF
--- a/src/providers/anthropic-base/messages.ts
+++ b/src/providers/anthropic-base/messages.ts
@@ -48,6 +48,10 @@ export const messagesBaseConfig: ProviderConfig = {
     param: 'thinking',
     required: false,
   },
+  effort: {
+    param: 'effort',
+    required: false,
+  },
   tool_choice: {
     param: 'tool_choice',
     required: false,

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -495,6 +495,10 @@ export const AnthropicChatCompleteConfig: ProviderConfig = {
     param: 'thinking',
     required: false,
   },
+  effort: {
+    param: 'effort',
+    required: false,
+  },
 };
 
 interface AnthorpicTextContentItem {

--- a/src/providers/bedrock/utils/messagesUtils.ts
+++ b/src/providers/bedrock/utils/messagesUtils.ts
@@ -34,6 +34,9 @@ export const transformAnthropicAdditionalModelRequestFields = (
   if (params['thinking']) {
     additionalModelRequestFields['thinking'] = params['thinking'];
   }
+  if (params['effort']) {
+    additionalModelRequestFields['effort'] = params['effort'];
+  }
   if (params['anthropic_beta']) {
     if (typeof params['anthropic_beta'] === 'string') {
       additionalModelRequestFields['anthropic_beta'] = [

--- a/src/types/MessagesRequest.ts
+++ b/src/types/MessagesRequest.ts
@@ -348,9 +348,16 @@ export interface ThinkingConfigDisabled {
   type: 'disabled';
 }
 
+export interface ThinkingConfigAdaptive {
+  budget_tokens?: number;
+
+  type: 'adaptive';
+}
+
 export type ThinkingConfigParam =
   | ThinkingConfigEnabled
-  | ThinkingConfigDisabled;
+  | ThinkingConfigDisabled
+  | ThinkingConfigAdaptive;
 
 /**
  * The model will use any available tools.
@@ -633,6 +640,11 @@ export interface MessageCreateParamsBase {
    * Configuration for enabling Claude's extended thinking.
    */
   thinking?: ThinkingConfigParam;
+
+  /**
+   * Controls how much effort the model puts into reasoning.
+   */
+  effort?: 'high' | 'medium' | 'low';
 
   /**
    * How the model should use the provided tools. The model can use a specific tool,

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -435,8 +435,9 @@ export interface Params {
   anthropic_version?: string;
   thinking?: {
     type?: string;
-    budget_tokens: number;
+    budget_tokens?: number;
   };
+  effort?: string;
   // Embeddings specific
   dimensions?: number;
   parameters?: any;


### PR DESCRIPTION
- Add `effort` (high/medium/low) passthrough for Anthropic direct, Messages API, and Bedrock providers
- Add `ThinkingConfigAdaptive` type with optional `budget_tokens` for `thinking.type: 'adaptive'`
- Make `budget_tokens` optional in Params to support adaptive thinking mode

Files changed: 5 files, ~26 lines added